### PR TITLE
Rename inspect to log and fix other namings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ Options:
 
 **NOTE**: `Forward` default HTTP method is POST, while request.js' one is GET.
 
-#### Inspect
+#### Print
 
-Inspect command just print each event to the standard output
+Print command just print each event to the standard output
 
 Options:
 
-- `inspect.prompt`: A prompt to display along with the event
-- `inspect.depth`: `depth` to pass to `util.inspect` default to `null`
+- `Print.prompt`: A prompt to display along with the event
+- `Print.depth`: `depth` to pass to `util.Print` default to `null`
 
 ## Programmatic Api
 
@@ -86,24 +86,24 @@ The core is independent from specific sources and allows for different
 commands implementation and extension:
 
 ``` js
-EventSource.register('myEventSourceName', MyEventSource);
+Source.register('mySourceName', MySource);
 Command.register('myCommandName', MyCommand);
 
-var eventMapper = new EventMapper();
+var Processor = new Processor();
 
-eventMapper.configure(config);
-eventMapper.listen();
+Processor.configure(config);
+Processor.listen();
 ```
 
-### Implementing an EventSource
+### Implementing an Source
 
-1. Extend EventSource and implement listen()
-2. Register the new event source into EventMapper;
+1. Extend Source and implement listen()
+2. Register the new event source into Processor;
 
-NOTE: config for the eventsource will be available in `this.config`.
+NOTE: config for the Source will be available in `this.config`.
 
 ``` js
-class MyEventSource extends EventSource {
+class MySource extends Source {
 
   listen() {
     setInterval(() => {
@@ -115,7 +115,7 @@ class MyEventSource extends EventSource {
 
 }
 
-EventSource.register('MySource', MyEventSource);
+Source.register('MySource', MySource);
 ```
 
 ``` json
@@ -132,9 +132,9 @@ EventSource.register('MySource', MyEventSource);
 ### Implementing a Command
 
 1. Extend Command and implement run()
-2. Register the new command into EventMapper;
+2. Register the new command into Processor;
 
-NOTE: config for the eventsource will be available in `this.config`.
+NOTE: config for the Source will be available in `this.config`.
 
 ``` js
 class MailCommand extends Command {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/mcasimir/evp#readme",
   "devDependencies": {
+    "glob": "^5.0.15",
     "gulp": "^3.9.0",
     "gulp-jasmine": "^2.0.1",
     "gulp-jshint": "^1.11.2",

--- a/src/Command.js
+++ b/src/Command.js
@@ -50,7 +50,7 @@ class Command {
   }
 
   constructor(config) {
-    this.config = config;
+    this.config = config || {};
   }
 
   /**

--- a/src/Processor.js
+++ b/src/Processor.js
@@ -4,7 +4,7 @@ var _         = require('lodash');
 var JsonDsl  = require('./dsl/JsonDsl');
 var EventEmitter = require('events');
 
-class EventMapper extends EventEmitter {
+class Processor extends EventEmitter {
 
   constructor(config) {
     super();
@@ -41,4 +41,4 @@ class EventMapper extends EventEmitter {
 
 }
 
-module.exports = EventMapper;
+module.exports = Processor;

--- a/src/Source.js
+++ b/src/Source.js
@@ -2,7 +2,7 @@
 
 var EventEmitter = require('events');
 
-class EventSource extends EventEmitter {
+class Source extends EventEmitter {
 
   static _registryGetSet(name, value) {
     this.registry = this.registry || {};
@@ -21,7 +21,7 @@ class EventSource extends EventEmitter {
   }
 
   static extend(obj) {
-    return class extends EventSource {
+    return class extends Source {
       constructor(name, config) {
         super(name, config);
         Object.assign(this, obj);
@@ -82,4 +82,4 @@ class EventSource extends EventEmitter {
   listen() { }
 }
 
-module.exports = EventSource;
+module.exports = Source;

--- a/src/commands/Log.js
+++ b/src/commands/Log.js
@@ -18,9 +18,13 @@ class Log extends Command {
 
     args.push(inspect(event, { depth: this.config.depth }));
 
-    console.log.apply(console, args);
+    this._log.apply(this, args);
 
     return Promise.resolve(event);
+  }
+
+  _log() {
+    console.log.apply(console, arguments);
   }
 
 }

--- a/src/commands/Log.js
+++ b/src/commands/Log.js
@@ -3,7 +3,7 @@
 var inspect = require('util').inspect;
 var Command   = require('../Command');
 
-class Inspect extends Command {
+class Log extends Command {
 
   run(event){
     var now    = (new Date());
@@ -25,4 +25,4 @@ class Inspect extends Command {
 
 }
 
-module.exports = Inspect;
+module.exports = Log;

--- a/src/dsl/JsonDsl.js
+++ b/src/dsl/JsonDsl.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 var Command = require('../Command');
-var EventSource = require('../EventSource');
+var Source = require('../Source');
 var Pipeline = require('../Pipeline');
 var JsonDslError = require('./JsonDslError');
 
@@ -35,9 +35,9 @@ class JsonDsl {
   }
 
   parseSource(name, definition) {
-    var source = EventSource.create(definition.type, name, definition.config);
+    var source = Source.create(definition.type, name, definition.config);
     if (!source) {
-      throw new JsonDslError(`Unable to find an EventSource for type ${definition.type}`);
+      throw new JsonDslError(`Unable to find an Source for type ${definition.type}`);
     }
     source.pipelines.push(this.parsePipeline(definition.process));
 

--- a/src/evp.js
+++ b/src/evp.js
@@ -1,15 +1,22 @@
 'use strict';
 
 var Processor           = require('./Processor');
-var Transform           = require('./commands/Transform');
-var Forward             = require('./commands/Forward');
-var Log                 = require('./commands/Log');
 var Source              = require('./Source');
 var Command             = require('./Command');
 
-Command.register('transform', Transform);
+var Discard             = require('./commands/Discard');
+var Forward             = require('./commands/Forward');
+var If                  = require('./commands/If');
+var Log                 = require('./commands/Log');
+var Switch              = require('./commands/Switch');
+var Transform           = require('./commands/Transform');
+
+Command.register('discard', Discard);
 Command.register('forward', Forward);
+Command.register('if', If);
 Command.register('log', Log);
+Command.register('switch', Switch);
+Command.register('transform', Transform);
 
 var evp = new Processor();
 

--- a/src/evp.js
+++ b/src/evp.js
@@ -1,27 +1,27 @@
 'use strict';
 
-var EventMapper         = require('./EventMapper');
+var Processor           = require('./Processor');
 var Transform           = require('./commands/Transform');
 var Forward             = require('./commands/Forward');
-var Inspect             = require('./commands/Inspect');
-var EventSource         = require('./EventSource');
+var Log                 = require('./commands/Log');
+var Source              = require('./Source');
 var Command             = require('./Command');
 
 Command.register('transform', Transform);
 Command.register('forward', Forward);
-Command.register('inspect', Inspect);
+Command.register('log', Log);
 
-var evp = new EventMapper();
+var evp = new Processor();
 
 evp.registerCommand = function(name, cmd) {
   return Command.register(name, cmd);
 };
 
 evp.registerSource = function(name, src) {
-  return EventSource.register(name, src);
+  return Source.register(name, src);
 };
 
-evp.EventSource = EventSource;
+evp.Source = Source;
 evp.Command = Command;
 
 module.exports = evp;

--- a/test/Command.spec.js
+++ b/test/Command.spec.js
@@ -4,6 +4,12 @@ let Command = require('../src/Command');
 
 describe('Command', function() {
 
+  describe('constructor', function(){
+    it('sets configuration to {} as default', function() {
+      expect((new Command()).config).toEqual({});
+    });
+  });
+
   describe('extends', function() {
     it('creates a new command class', function() {
       let now = (new Date()).getTime();

--- a/test/JsonDsl.spec.js
+++ b/test/JsonDsl.spec.js
@@ -3,7 +3,7 @@
 var JsonDsl = require('../src/dsl/JsonDsl');
 var JsonDslError = require('../src/dsl/JsonDslError');
 var Command = require('../src/Command');
-var EventSource = require('../src/EventSource');
+var Source = require('../src/Source');
 var dsl;
 
 describe('JsonDsl', function() {
@@ -11,7 +11,7 @@ describe('JsonDsl', function() {
   beforeEach(function() {
     dsl = new JsonDsl();
     delete Command.registry;
-    delete EventSource.registry;
+    delete Source.registry;
   });
 
 
@@ -44,8 +44,8 @@ describe('JsonDsl', function() {
 
   describe('parseSource', function(){
     it('Returns a new source with a registered source', function() {
-      var Src1 = class extends EventSource {};
-      EventSource.register('src1', Src1);
+      var Src1 = class extends Source {};
+      Source.register('src1', Src1);
       var parsed = dsl.parseSource('xyz', {type: 'src1'});
       expect(parsed instanceof Src1).toBe(true);
     });
@@ -58,15 +58,15 @@ describe('JsonDsl', function() {
     });
 
     it('Passes config to source created', function() {
-      var Src1 = class extends EventSource {};
-      EventSource.register('src1', Src1);
+      var Src1 = class extends Source {};
+      Source.register('src1', Src1);
       var parsed = dsl.parseSource('xyz', {type: 'src1', config: { x: 5 }});
       expect(parsed.config.x).toBe(5);
     });
 
     it('Passes name to source created', function() {
-      var Src1 = class extends EventSource {};
-      EventSource.register('src1', Src1);
+      var Src1 = class extends Source {};
+      Source.register('src1', Src1);
       var parsed = dsl.parseSource('xyz', {type: 'src1'});
       expect(parsed.name).toBe('xyz');
     });

--- a/test/JsonDsl.spec.js
+++ b/test/JsonDsl.spec.js
@@ -38,8 +38,8 @@ describe('JsonDsl', function() {
     });
   });
 
-  xdescribe('parsePipeline', function(){
-
+  describe('parsePipeline', function(){
+    xit('todo', function(){});
   });
 
   describe('parseSource', function(){
@@ -73,11 +73,11 @@ describe('JsonDsl', function() {
   });
 
   describe('parsePair', function(){
-
+    xit('todo', function(){});
   });
 
-  xdescribe('parse', function(){
-
+  describe('parse', function(){
+    xit('todo', function(){});
   });
 
 });

--- a/test/Log.spec.js
+++ b/test/Log.spec.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var Log = require('../src/commands/Log');
+
+describe('Log', function() {
+
+  describe('run', function() {
+
+    it('should pass through the original event untouched', function(done) {
+      var event = {
+        a: {
+          b: {
+            c: 'OK'
+          }
+        }
+      };
+
+      var bkp = JSON.parse(JSON.stringify(event));
+
+      var cmd = new Log();
+
+      cmd.run(event).then(function(evt) {
+        expect(evt).toEqual(bkp);
+        done();
+      });
+    });
+
+    it('should call console.log', function(done) {
+      spyOn(console, 'log');
+      
+      var event = {
+        a: {
+          b: {
+            c: 'OK'
+          }
+        }
+      };
+
+      var cmd = new Log();
+
+      cmd.run(event).then(function() {
+        expect(console.log).toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+});

--- a/test/Processor.spec.js
+++ b/test/Processor.spec.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var EventSource = require('../src/EventSource');
+var Source = require('../src/Source');
 var Command = require('../src/Command');
-var EventMapper = require('../src/EventMapper');
-var eventMapper = new EventMapper();
+var Processor = require('../src/Processor');
+var Processor = new Processor();
 
 class DummyCommand extends Command {
   run(event){
@@ -17,7 +17,7 @@ class ErrorCommand extends Command {
   }
 }
 
-class DummySource extends EventSource {
+class DummySource extends Source {
   listen() {
     this.event({
       time: (new Date()).getTime()
@@ -25,17 +25,17 @@ class DummySource extends EventSource {
   }
 }
 
-describe('EventMapper', function() {
+describe('Processor', function() {
 
   beforeEach(() => {
-    EventSource.register('dummySource', DummySource);
+    Source.register('dummySource', DummySource);
     Command.register('dummy', DummyCommand);
     Command.register('error', ErrorCommand);
   });
 
   describe('can be used very easily', function() {
     it('can hook up a source with a command', function(done) {
-      eventMapper.configure({
+      Processor.configure({
         dummySource: {
           type: 'dummySource',
           config: {},
@@ -45,9 +45,9 @@ describe('EventMapper', function() {
         }
       });
 
-      eventMapper.listen();
+      Processor.listen();
 
-      eventMapper.on('eventProcessed', (e) => {
+      Processor.on('eventProcessed', (e) => {
         expect(e.source.name).toEqual('dummySource');
         expect(e.result.time).toBeDefined();
         done();
@@ -55,7 +55,7 @@ describe('EventMapper', function() {
     });
 
     it('notifies about an event failure', function(done) {
-      eventMapper.configure({
+      Processor.configure({
         dummySource: {
           type: 'dummySource',
           config: {},
@@ -65,9 +65,9 @@ describe('EventMapper', function() {
         }
       });
 
-      eventMapper.listen();
+      Processor.listen();
 
-      eventMapper.on('eventProcessingError', (e) => {
+      Processor.on('eventProcessingError', (e) => {
         expect(e.source.name).toEqual('dummySource');
         done();
       });

--- a/test/Source.spec.js
+++ b/test/Source.spec.js
@@ -1,11 +1,11 @@
 'use strict';
 
-let EventSource = require('../src/EventSource');
+let Source = require('../src/Source');
 
-describe('EventSource', function() {
+describe('Source', function() {
 
   beforeEach(function(){
-    delete EventSource.registry;
+    delete Source.registry;
   });
 
   describe('extends', function() {
@@ -16,9 +16,9 @@ describe('EventSource', function() {
         return now;
       };
 
-      let SrcClass = EventSource.extend({ listen: fn });
+      let SrcClass = Source.extend({ listen: fn });
       let src = new SrcClass();
-      expect(src instanceof EventSource).toBe(true);
+      expect(src instanceof Source).toBe(true);
 
       expect(src.listen()).toBe(now);
     });
@@ -33,41 +33,41 @@ describe('EventSource', function() {
         return now;
       };
 
-      let src = EventSource.create({ listen: fn });
-      expect(src instanceof EventSource).toBe(true);
+      let src = Source.create({ listen: fn });
+      expect(src instanceof Source).toBe(true);
       expect(src.listen()).toBe(now);
     });
 
     it('creates a registered source', function() {
-      class Src extends EventSource {}
-      EventSource.register('src', Src);
-      let src = EventSource.create('src');
+      class Src extends Source {}
+      Source.register('src', Src);
+      let src = Source.create('src');
       expect(src instanceof Src).toBe(true);
     });
 
     it('does not create a source not registered', function() {
-      let src = EventSource.create('src');
+      let src = Source.create('src');
       expect(src).toBe(null);
     });
 
     it('always sets config to empty object if config is not passed', function() {
-      class Src extends EventSource {}
-      EventSource.register('src', Src);
-      let src = EventSource.create('src');
+      class Src extends Source {}
+      Source.register('src', Src);
+      let src = Source.create('src');
       expect(src.config).toEqual({});
     });
 
     it('passes config to created instance', function() {
-      class Src extends EventSource {}
-      EventSource.register('src', Src);
-      let src = EventSource.create('src', 'name', {x: 5});
+      class Src extends Source {}
+      Source.register('src', Src);
+      let src = Source.create('src', 'name', {x: 5});
       expect(src.config).toEqual({x: 5});
     });
 
     it('passes name to created instance', function() {
-      class Src extends EventSource {}
-      EventSource.register('src', Src);
-      let src = EventSource.create('src', 'xyz', {x: 5});
+      class Src extends Source {}
+      Source.register('src', Src);
+      let src = Source.create('src', 'xyz', {x: 5});
       expect(src.name).toEqual('xyz');
     });
   });
@@ -76,10 +76,10 @@ describe('EventSource', function() {
 
     it('registers a new source', function() {
       let fn = function() {};
-      EventSource.register('newEventSource', fn);
-      expect(EventSource.registry).toBeDefined();
-      if (EventSource.registry) {
-        expect(EventSource.registry.newEventSource).toBe(fn);
+      Source.register('newSource', fn);
+      expect(Source.registry).toBeDefined();
+      if (Source.registry) {
+        expect(Source.registry.newSource).toBe(fn);
       }
     });
 
@@ -89,16 +89,16 @@ describe('EventSource', function() {
 
     it('gets a registered source', function() {
       let fn = function() {};
-      EventSource.register('newEventSource', fn);
-      expect(EventSource.get('newEventSource')).toBe(fn);
+      Source.register('newSource', fn);
+      expect(Source.get('newSource')).toBe(fn);
     });
 
     it('does not throw and returns falsy on unregistered sources', function() {
       expect(function() {
-        EventSource.get('newEventSource');
+        Source.get('newSource');
       }).not.toThrow();
 
-      expect(EventSource.get('newEventSource')).toBeFalsy();
+      expect(Source.get('newSource')).toBeFalsy();
     });
 
   });
@@ -109,7 +109,7 @@ describe('EventSource', function() {
       let conf = {x: 5};
       let internalConf;
 
-      let Src = EventSource.extend({
+      let Src = Source.extend({
         listen: function() {
           internalConf = this.config;
         }

--- a/test/evp.spec.js
+++ b/test/evp.spec.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var evp = require('../src/evp');
+var Processor = require('../src/Processor');
+var Command = require('../src/Command');
+var Source = require('../src/Source');
+
+describe('evp', function() {
+  beforeEach(function() {
+    delete Command.registry;
+    delete Source.registry;
+  });
+
+  it('should be a Processor', function() {
+    expect(evp instanceof Processor).toBe(true);
+  });
+
+  it('should expose Command class', function() {
+    expect(evp.Command).toBe(Command);
+  });
+
+  it('should expose Source class', function() {
+    expect(evp.Source).toBe(Source);
+  });
+
+  it('should allow to register a new Command with class', function() {
+    class Cmd1 extends Command {}
+    evp.registerCommand('cmd', Cmd1);
+    expect(Command.get('cmd')).toBe(Cmd1);
+  });
+
+  it('should allow to register a new Source with class', function() {
+    class Src1 extends Source {}
+    evp.registerSource('src', Src1);
+    expect(Source.get('src')).toBe(Src1);
+  });
+
+});

--- a/test/evp.spec.js
+++ b/test/evp.spec.js
@@ -4,6 +4,8 @@ var evp = require('../src/evp');
 var Processor = require('../src/Processor');
 var Command = require('../src/Command');
 var Source = require('../src/Source');
+var glob = require('glob');
+var path = require('path');
 
 describe('evp', function() {
   beforeEach(function() {
@@ -33,6 +35,15 @@ describe('evp', function() {
     class Src1 extends Source {}
     evp.registerSource('src', Src1);
     expect(Source.get('src')).toBe(Src1);
+  });
+
+  xit('should make all the defined commands available', function() {
+    // glob(path.resolve(__dirname, '../src/commands/*.js'), {nonull: false, nodir: true}, function (er, files) {
+    //   files.forEach(function(file) {
+    //     var className = path.basename(file, '.js');
+    //   });
+    //   done();
+    // });
   });
 
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var evp = require('..');
+var Processor = require('../src/Processor');
+
+describe('index.js', function() {
+  it('should export evp', function() {
+    expect(evp instanceof Processor).toBe(true);
+    expect(typeof evp.registerCommand).toBe('function');
+    expect(typeof evp.registerSource).toBe('function');
+  });
+});


### PR DESCRIPTION
`inspect` was causing issues with console.log(evp) and EventSource is taken in global scope for browsers.
